### PR TITLE
fix compilation/linking on debian/ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all: $(FOLDERS) kadimus
 
 kadimus: $(OBJS)
 	@echo "  CC $@"
-	@$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^
+	@$(CC) -o $@ $^ $(CFLAGS) $(LDFLAGS)
 
 $(FOLDERS):
 	@echo "  MKDIR $@"


### PR DESCRIPTION
Hi,

not sure you'll be interested in this, but I got problems compiling kadimus on Debian/Ubuntu (See below) and changing the order in `Makefile` did fix it.

Compilation logs:
```sh
make
  CC bin/io/utils.o
  CC bin/techniques/php-input.o
  CC bin/techniques/environ.o
  CC bin/techniques/php-filter.o
  CC bin/techniques/auth-log-poison.o
  CC bin/techniques/datawrap.o
  CC bin/techniques/expect.o
  CC bin/string/hexdump.o
  CC bin/string/url.o
  CC bin/string/base64.o
  CC bin/string/concat.o
  CC bin/string/diff.o
  CC bin/string/urlencode.o
  CC bin/string/utils.o
  CC bin/memory/alloc.o
  CC bin/scan/scan.o
  CC bin/scan/rce-scan.o
  CC bin/fun/http-shell.o
  CC bin/fun/exec-php-code.o
  CC bin/fun/exec-cmd.o
  CC bin/regex/pcre.o
  CC bin/request/request.o
  CC bin/net/listen.o
  CC bin/net/xconnect.o
  CC bin/net/utils.o
  CC bin/output.o
  CC bin/globals.o
  CC bin/kadimus.o
  CC kadimus
/usr/bin/ld : bin/kadimus.o : dans la fonction « init_global_structs » :
kadimus.c:(.text+0x90a) : référence indéfinie vers « curl_global_init »
/usr/bin/ld : bin/techniques/php-input.o : dans la fonction « php_input_rce » :
php-input.c:(.text+0x7c) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : php-input.c:(.text+0x90) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : php-input.c:(.text+0xac) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : bin/techniques/environ.o : dans la fonction « proc_env_rce » :
environ.c:(.text+0xa9) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : environ.c:(.text+0xbd) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : bin/techniques/php-filter.o:php-filter.c:(.text+0x7c) : encore plus de références indéfinies suivent vers « curl_easy_setopt »
/usr/bin/ld : bin/techniques/auth-log-poison.o : dans la fonction « auth_log_poison » :
auth-log-poison.c:(.text+0x17) : référence indéfinie vers « ssh_new »
/usr/bin/ld : auth-log-poison.c:(.text+0x2c) : référence indéfinie vers « ssh_options_set »
/usr/bin/ld : auth-log-poison.c:(.text+0x3c) : référence indéfinie vers « ssh_connect »
/usr/bin/ld : auth-log-poison.c:(.text+0x59) : référence indéfinie vers « ssh_userauth_password »
/usr/bin/ld : auth-log-poison.c:(.text+0x66) : référence indéfinie vers « ssh_disconnect »
/usr/bin/ld : auth-log-poison.c:(.text+0x6e) : référence indéfinie vers « ssh_free »
/usr/bin/ld : auth-log-poison.c:(.text+0x8a) : référence indéfinie vers « ssh_get_error »
/usr/bin/ld : auth-log-poison.c:(.text+0xb6) : référence indéfinie vers « ssh_options_set »
/usr/bin/ld : auth-log-poison.c:(.text+0xbe) : référence indéfinie vers « ssh_connect »
/usr/bin/ld : bin/techniques/auth-log-poison.o : dans la fonction « auth_log_rce » :
auth-log-poison.c:(.text+0x1df) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : auth-log-poison.c:(.text+0x1f3) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : auth-log-poison.c:(.text+0x20f) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : auth-log-poison.c:(.text+0x223) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : bin/techniques/datawrap.o : dans la fonction « datawrap_rce » :
datawrap.c:(.text+0xe4) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : bin/techniques/expect.o:expect.c:(.text+0xc1) : encore plus de références indéfinies suivent vers « curl_easy_setopt »
/usr/bin/ld : bin/regex/pcre.o : dans la fonction « xpcre_compile » :
pcre.c:(.text+0x12) : référence indéfinie vers « pcre_compile »
/usr/bin/ld : bin/regex/pcre.o : dans la fonction « regex_extract » :
pcre.c:(.text+0x92) : référence indéfinie vers « pcre_exec »
/usr/bin/ld : pcre.c:(.text+0xfa) : référence indéfinie vers « pcre_free »
/usr/bin/ld : pcre.c:(.text+0x120) : référence indéfinie vers « pcre_free »
/usr/bin/ld : bin/regex/pcre.o : dans la fonction « regex_match » :
pcre.c:(.text+0x1bf) : référence indéfinie vers « pcre_exec »
/usr/bin/ld : pcre.c:(.text+0x1ca) : référence indéfinie vers « pcre_free »
/usr/bin/ld : bin/regex/pcre.o : dans la fonction « regex_matchv2 » :
pcre.c:(.text+0x206) : référence indéfinie vers « pcre_exec »
/usr/bin/ld : bin/request/request.o : dans la fonction « request_init » :
request.c:(.text+0xc9) : référence indéfinie vers « curl_easy_init »
/usr/bin/ld : request.c:(.text+0xef) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x103) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x119) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x12f) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x140) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : bin/request/request.o:request.c:(.text+0x151) : encore plus de références indéfinies suivent vers « curl_easy_setopt »
/usr/bin/ld : bin/request/request.o : dans la fonction « request_init_fh » :
request.c:(.text+0x239) : référence indéfinie vers « curl_easy_init »
/usr/bin/ld : request.c:(.text+0x25f) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x273) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x289) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x29f) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : request.c:(.text+0x2b0) : référence indéfinie vers « curl_easy_setopt »
/usr/bin/ld : bin/request/request.o:request.c:(.text+0x2c1) : encore plus de références indéfinies suivent vers « curl_easy_setopt »
/usr/bin/ld : bin/request/request.o : dans la fonction « request_exec » :
request.c:(.text+0x32c) : référence indéfinie vers « curl_easy_perform »
/usr/bin/ld : request.c:(.text+0x39a) : référence indéfinie vers « curl_easy_strerror »
/usr/bin/ld : request.c:(.text+0x3c7) : référence indéfinie vers « curl_easy_strerror »
/usr/bin/ld : bin/request/request.o : dans la fonction « request_free » :
request.c:(.text+0x409) : référence indéfinie vers « curl_easy_cleanup »
/usr/bin/ld : bin/request/request.o : dans la fonction « request_init_fh » :
request.c:(.text+0x2dd) : référence indéfinie vers « curl_easy_setopt »
collect2: error: ld returned 1 exit status
make: *** [Makefile:14: kadimus] Error 1
```